### PR TITLE
Fix new role display_name

### DIFF
--- a/src/Roles.php
+++ b/src/Roles.php
@@ -81,7 +81,7 @@ class Roles
         $role = get_role($roleId);
 
         if (!$role) {
-            $role = add_role($desiredRoleId, $desiredRole['display_name']);
+            $role = add_role($roleId, $this->desiredRoles[$roleId]['display_name'] ?? '');
         }
 
         return $role;


### PR DESCRIPTION
This PR fixes the creation of a new role. Seems like the display_name has been missing/the array was not added as param.
